### PR TITLE
adds http 1.0

### DIFF
--- a/src/http/ut-http-client.c
+++ b/src/http/ut-http-client.c
@@ -120,6 +120,7 @@ static void connect_cb(UtObject *object, UtObject *error) {
 
   UtObjectRef headers = ut_list_new();
   ut_list_append_take(headers, ut_http_header_new("Host", request->host));
+  ut_list_append_take(headers, ut_http_header_new("Connection", "close"));
   request->message_encoder = ut_http_message_encoder_new_request(
       request->tcp_socket, request->method, request->path, headers,
       request->body);

--- a/src/http/ut-http-message-decoder.c
+++ b/src/http/ut-http-message-decoder.c
@@ -122,6 +122,11 @@ static char *get_string(UtObject *data, size_t start, size_t end) {
   return ut_string_take_text(string);
 }
 
+static bool valid_http_version(ut_cstring_ref protocol_version) {
+  return ut_cstring_equal(protocol_version, "HTTP/1.1") ||
+         ut_cstring_equal(protocol_version, "HTTP/1.0");
+}
+
 static bool parse_request_line(UtHttpMessageDecoder *self, UtObject *data) {
   size_t method_start = 0;
   ssize_t method_end = find_character(data, method_start, ' ');
@@ -141,7 +146,7 @@ static bool parse_request_line(UtHttpMessageDecoder *self, UtObject *data) {
   size_t protocol_version_end = ut_list_get_length(data);
   ut_cstring_ref protocol_version =
       get_string(data, protocol_version_start, protocol_version_end);
-  if (!ut_cstring_equal(protocol_version, "HTTP/1.1")) {
+  if (!valid_http_version(protocol_version)) {
     set_error(self, "Invalid HTTP version");
     return false;
   }
@@ -162,7 +167,7 @@ static bool parse_status_line(UtHttpMessageDecoder *self, UtObject *data) {
   }
   ut_cstring_ref protocol_version =
       get_string(data, protocol_version_start, protocol_version_end);
-  if (!ut_cstring_equal(protocol_version, "HTTP/1.1")) {
+  if (!valid_http_version(protocol_version)) {
     set_error(self, "Invalid HTTP version");
     return false;
   }


### PR DESCRIPTION
Allows http 1.0 server responses (for example `python3.12 -m SimpleHTTPServer 9000`) is http 1.0
Client request always adds: Connection: close - Because we don't support keeping the connection alive, so the server will close the connection.